### PR TITLE
CLIO-24318: Fix typo for Contacts and Activities

### DIFF
--- a/lib/clio_client/api/activity.rb
+++ b/lib/clio_client/api/activity.rb
@@ -9,7 +9,7 @@ module ClioClient
       private
       def data_klass(attributes)
         accepted_types = %w(TimeEntry ExpenseEntry)
-        type = attributes["type"] || attriutes[:type]
+        type = attributes["type"] || attributes[:type]
         if accepted_types.include? type
           ClioClient.const_get type
         else

--- a/lib/clio_client/api/contact.rb
+++ b/lib/clio_client/api/contact.rb
@@ -9,7 +9,7 @@ module ClioClient
       private
       def data_klass(attributes)
         accepted_types = %w(Person Company)
-        type = attributes["type"] || attriutes[:type]
+        type = attributes["type"] || attributes[:type]
         if accepted_types.include? type
           ClioClient.const_get type
         else

--- a/spec/api/activities_spec.rb
+++ b/spec/api/activities_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ClioClient::Api::Activity do
+  let(:session) { double("ClioClient::Api::Session") }
+  subject {
+    ClioClient::Api::Activity.new(session)
+  }
+
+  context "of type TimeEntry" do
+    let(:type_value) { "TimeEntry" }
+    let(:type_klass) { ClioClient::TimeEntry }
+
+    include_examples "typed resource"
+  end
+
+  context "of type ExpenseEntry" do
+    let(:type_value) { "ExpenseEntry" }
+    let(:type_klass) { ClioClient::ExpenseEntry }
+
+    include_examples "typed resource"
+  end
+end

--- a/spec/api/contact_spec.rb
+++ b/spec/api/contact_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ClioClient::Api::Contact do
+  let(:session) { double("ClioClient::Api::Session") }
+  subject {
+    ClioClient::Api::Contact.new(session)
+  }
+
+  context "of type Company" do
+    let(:type_value) { "Company" }
+    let(:type_klass) { ClioClient::Company }
+    include_examples "typed resource"
+  end
+
+  context "of type Person" do
+    let(:type_value) { "Person" }
+    let(:type_klass) { ClioClient::Person }
+    include_examples "typed resource"
+  end
+
+
+end

--- a/spec/support/resource_examples.rb
+++ b/spec/support/resource_examples.rb
@@ -80,3 +80,22 @@ shared_examples "model initialization" do
 
 end
 
+shared_examples "typed resource" do
+
+  it "should accept type key as a string" do
+    verify_type_key( { "type" => type_value } )
+  end
+
+  it "should accept type key as a symbol" do
+    verify_type_key( { type: type_value } )
+
+  end
+
+  def verify_type_key(attributes)
+    record = subject.new(attributes)
+    expect(record).to be_kind_of type_klass
+    expect(record.type).to eql type_value
+  end
+
+end
+


### PR DESCRIPTION
When instantiating a Contact or Activities, if the 'type' attribute is passed in JSON style (ie: type: 'Company'), an error will occur about an undefined local variable method named 'attriutes'. This PR fixes that typo and adds unit tests.